### PR TITLE
Added support for merge_train endpoint

### DIFF
--- a/src/Api/MergeRequests.php
+++ b/src/Api/MergeRequests.php
@@ -202,6 +202,11 @@ class MergeRequests extends AbstractApi
         return $this->put($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/merge'), $parameters);
     }
 
+    public function mergeTrain($project_id, int $mr_iid, array $parameters = [])
+    {
+        return $this->put($this->getProjectPath($project_id, 'merge_trains/merge_requests/'.self::encodePath($mr_iid)), $parameters);
+    }
+
     public function showNotes(int|string $project_id, int $mr_iid): mixed
     {
         return $this->get($this->getProjectPath($project_id, 'merge_requests/'.self::encodePath($mr_iid).'/notes'));


### PR DESCRIPTION
The merge train endpoint allows a merge request to be added to a merge train, rather then merging directly.